### PR TITLE
Fix IK flow

### DIFF
--- a/src/@types/handshake-interface.ts
+++ b/src/@types/handshake-interface.ts
@@ -1,8 +1,10 @@
 import {bytes} from "./basic";
 import {NoiseSession} from "./handshake";
+import PeerId from "peer-id";
 
 export interface IHandshake {
   session: NoiseSession;
+  remotePeer: PeerId;
   encrypt(plaintext: bytes, session: NoiseSession): bytes;
   decrypt(ciphertext: bytes, session: NoiseSession): bytes;
 }

--- a/src/@types/handshake.ts
+++ b/src/@types/handshake.ts
@@ -37,3 +37,9 @@ export type NoiseSession = {
   mc: uint64;
   i: boolean;
 }
+
+export interface INoisePayload {
+  identityKey: bytes;
+  identitySig: bytes;
+  data: bytes;
+}

--- a/src/handshake-ik.ts
+++ b/src/handshake-ik.ts
@@ -56,9 +56,8 @@ export class IKHandshake implements IHandshake {
       try {
         const receivedMessageBuffer = decode1(receivedMsg);
         const plaintext = this.ik.recvMessage(this.session, receivedMessageBuffer);
-        this.remotePeer = await getPeerIdFromPayload(plaintext);
         logger("IK Stage 0 - Responder got message, going to verify payload.");
-        await verifySignedPayload(receivedMessageBuffer.ns, plaintext, this.remotePeer.id);
+        this.remotePeer = await verifySignedPayload(receivedMessageBuffer.ns, plaintext, this.remotePeer);
         logger("IK Stage 0 - Responder successfully verified payload!");
       } catch (e) {
         logger("Responder breaking up with IK handshake in stage 0.");
@@ -77,7 +76,7 @@ export class IKHandshake implements IHandshake {
       logger("IK Stage 1 - Initiator got message, going to verify payload.");
 
       try {
-        await verifySignedPayload(receivedMessageBuffer.ns, plaintext, this.remotePeer.id);
+        await verifySignedPayload(receivedMessageBuffer.ns, plaintext, this.remotePeer);
         logger("IK Stage 1 - Initiator successfully verified payload!");
       } catch (e) {
         logger("Initiator breaking up with IK handshake in stage 1.");

--- a/src/handshake-ik.ts
+++ b/src/handshake-ik.ts
@@ -101,7 +101,7 @@ export class IKHandshake implements IHandshake {
     return this.ik.encryptWithAd(cs, Buffer.alloc(0), plaintext);
   }
 
-  public getRemoteEphemeralKeys(): KeyPair {
+  public getLocalEphemeralKeys(): KeyPair {
     if (!this.session.hs.e) {
       throw new Error("Ephemeral keys do not exist.");
     }

--- a/src/handshake-xx-fallback.ts
+++ b/src/handshake-xx-fallback.ts
@@ -3,7 +3,7 @@ import {XXHandshake} from "./handshake-xx";
 import {XX} from "./handshakes/xx";
 import {KeyPair} from "./@types/libp2p";
 import {bytes, bytes32} from "./@types/basic";
-import {verifySignedPayload,} from "./utils";
+import {getPeerIdFromPayload, verifySignedPayload,} from "./utils";
 import {logger} from "./logger";
 import {WrappedConnection} from "./noise";
 import {decode0, decode1} from "./encoder";
@@ -19,8 +19,8 @@ export class XXFallbackHandshake extends XXHandshake {
     prologue: bytes32,
     staticKeypair: KeyPair,
     connection: WrappedConnection,
-    remotePeer: PeerId,
     initialMsg: bytes,
+    remotePeer?: PeerId,
     ephemeralKeys?: KeyPair,
     handshake?: XX,
   ) {
@@ -57,6 +57,7 @@ export class XXFallbackHandshake extends XXHandshake {
 
       logger("Initiator going to check remote's signature...");
       try {
+        this.remotePeer = await getPeerIdFromPayload(plaintext);
         await verifySignedPayload(receivedMessageBuffer.ns, plaintext, this.remotePeer.id);
       } catch (e) {
         throw new Error(`Error occurred while verifying signed payload from responder: ${e.message}`);

--- a/src/handshake-xx-fallback.ts
+++ b/src/handshake-xx-fallback.ts
@@ -57,8 +57,7 @@ export class XXFallbackHandshake extends XXHandshake {
 
       logger("Initiator going to check remote's signature...");
       try {
-        this.remotePeer = await getPeerIdFromPayload(plaintext);
-        await verifySignedPayload(receivedMessageBuffer.ns, plaintext, this.remotePeer.id);
+        this.remotePeer = await verifySignedPayload(receivedMessageBuffer.ns, plaintext, this.remotePeer);
       } catch (e) {
         throw new Error(`Error occurred while verifying signed payload from responder: ${e.message}`);
       }

--- a/src/handshake-xx.ts
+++ b/src/handshake-xx.ts
@@ -6,6 +6,7 @@ import { bytes, bytes32 } from "./@types/basic";
 import { NoiseSession } from "./@types/handshake";
 import {IHandshake} from "./@types/handshake-interface";
 import {
+  getPeerIdFromPayload,
   verifySignedPayload,
 } from "./utils";
 import { logger } from "./logger";
@@ -16,12 +17,12 @@ import PeerId from "peer-id";
 export class XXHandshake implements IHandshake {
   public isInitiator: boolean;
   public session: NoiseSession;
+  public remotePeer!: PeerId;
 
   protected payload: bytes;
   protected connection: WrappedConnection;
   protected xx: XX;
   protected staticKeypair: KeyPair;
-  protected remotePeer: PeerId;
 
   private prologue: bytes32;
 
@@ -31,7 +32,7 @@ export class XXHandshake implements IHandshake {
     prologue: bytes32,
     staticKeypair: KeyPair,
     connection: WrappedConnection,
-    remotePeer: PeerId,
+    remotePeer?: PeerId,
     handshake?: XX,
   ) {
     this.isInitiator = isInitiator;
@@ -39,8 +40,9 @@ export class XXHandshake implements IHandshake {
     this.prologue = prologue;
     this.staticKeypair = staticKeypair;
     this.connection = connection;
-    this.remotePeer = remotePeer;
-
+    if(remotePeer) {
+      this.remotePeer = remotePeer;
+    }
     this.xx = handshake || new XX();
     this.session = this.xx.initSession(this.isInitiator, this.prologue, this.staticKeypair);
   }
@@ -70,6 +72,7 @@ export class XXHandshake implements IHandshake {
 
       logger("Initiator going to check remote's signature...");
       try {
+        this.remotePeer = await getPeerIdFromPayload(plaintext);
         await verifySignedPayload(receivedMessageBuffer.ns, plaintext, this.remotePeer.id);
       } catch (e) {
         throw new Error(`Error occurred while verifying signed payload: ${e.message}`);
@@ -94,6 +97,7 @@ export class XXHandshake implements IHandshake {
       logger('Stage 2 - Responder waiting for third handshake message...');
       const receivedMessageBuffer = decode1(await this.connection.readLP());
       const plaintext = this.xx.recvMessage(this.session, receivedMessageBuffer);
+      this.remotePeer = await getPeerIdFromPayload(plaintext);
       logger('Stage 2 - Responder received the message, finished handshake. Got remote\'s static key.');
 
       try {

--- a/src/handshake-xx.ts
+++ b/src/handshake-xx.ts
@@ -72,8 +72,7 @@ export class XXHandshake implements IHandshake {
 
       logger("Initiator going to check remote's signature...");
       try {
-        this.remotePeer = await getPeerIdFromPayload(plaintext);
-        await verifySignedPayload(receivedMessageBuffer.ns, plaintext, this.remotePeer.id);
+        this.remotePeer = await verifySignedPayload(receivedMessageBuffer.ns, plaintext, this.remotePeer);
       } catch (e) {
         throw new Error(`Error occurred while verifying signed payload: ${e.message}`);
       }
@@ -97,11 +96,10 @@ export class XXHandshake implements IHandshake {
       logger('Stage 2 - Responder waiting for third handshake message...');
       const receivedMessageBuffer = decode1(await this.connection.readLP());
       const plaintext = this.xx.recvMessage(this.session, receivedMessageBuffer);
-      this.remotePeer = await getPeerIdFromPayload(plaintext);
       logger('Stage 2 - Responder received the message, finished handshake. Got remote\'s static key.');
 
       try {
-        await verifySignedPayload(receivedMessageBuffer.ns, plaintext, this.remotePeer.id);
+        this.remotePeer = await verifySignedPayload(receivedMessageBuffer.ns, plaintext, this.remotePeer);
       } catch (e) {
         throw new Error(`Error occurred while verifying signed payload: ${e.message}`);
       }

--- a/src/keycache.ts
+++ b/src/keycache.ts
@@ -7,8 +7,7 @@ import PeerId from "peer-id";
 class Keycache {
   private storage = new Map<bytes, bytes32>();
 
-  public store(peerId?: PeerId, key: bytes32): void {
-    if(!peerId) return;
+  public store(peerId: PeerId, key: bytes32): void {
     this.storage.set(peerId.id, key);
   }
 

--- a/src/keycache.ts
+++ b/src/keycache.ts
@@ -7,12 +7,16 @@ import PeerId from "peer-id";
 class Keycache {
   private storage = new Map<bytes, bytes32>();
 
-  public store(peerId: PeerId, key: bytes32): void {
+  public store(peerId?: PeerId, key: bytes32): void {
+    if(!peerId) return;
     this.storage.set(peerId.id, key);
   }
 
-  public load(peerId: PeerId): bytes32|undefined {
-    return this.storage.get(peerId.id);
+  public load(peerId?: PeerId): bytes32 | null {
+    if(!peerId) {
+      return null;
+    }
+    return this.storage.get(peerId.id) || null;
   }
 
   public resetStorage(): void {

--- a/src/noise.ts
+++ b/src/noise.ts
@@ -181,8 +181,8 @@ export class Noise implements INoiseConnection {
       await handshake.exchange();
       await handshake.finish();
 
-      if (this.useNoisePipes && remotePeer) {
-        KeyCache.store(remotePeer, handshake.getRemoteStaticKey());
+      if (this.useNoisePipes && handshake.remotePeer) {
+        KeyCache.store(handshake.remotePeer, handshake.getRemoteStaticKey());
       }
     } catch (e) {
       throw new Error(`Error occurred during XX handshake: ${e.message}`);

--- a/src/noise.ts
+++ b/src/noise.ts
@@ -12,7 +12,7 @@ import {XXFallbackHandshake} from "./handshake-xx-fallback";
 import {generateKeypair, getPayload} from "./utils";
 import {uint16BEDecode, uint16BEEncode} from "./encoder";
 import {decryptStream, encryptStream} from "./crypto";
-import {bytes, bytes32} from "./@types/basic";
+import {bytes} from "./@types/basic";
 import {INoiseConnection, KeyPair, SecureOutbound} from "./@types/libp2p";
 import {Duplex} from "./@types/it-pair";
 import {IHandshake} from "./@types/handshake-interface";

--- a/src/noise.ts
+++ b/src/noise.ts
@@ -181,7 +181,7 @@ export class Noise implements INoiseConnection {
       await handshake.exchange();
       await handshake.finish();
 
-      if (this.useNoisePipes) {
+      if (this.useNoisePipes && remotePeer) {
         KeyCache.store(remotePeer, handshake.getRemoteStaticKey());
       }
     } catch (e) {

--- a/src/noise.ts
+++ b/src/noise.ts
@@ -136,8 +136,8 @@ export class Noise implements INoiseConnection {
       } catch (e) {
         // IK failed, go to XX fallback
         let ephemeralKeys;
-        if (!params.isInitiator) {
-          ephemeralKeys = ikHandshake.getRemoteEphemeralKeys();
+        if (params.isInitiator) {
+          ephemeralKeys = ikHandshake.getLocalEphemeralKeys();
         }
         return await this.performXXFallbackHandshake(params, payload, e.initialMsg, ephemeralKeys);
       }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -5,7 +5,7 @@ import PeerId from "peer-id";
 import * as crypto from 'libp2p-crypto';
 import { KeyPair } from "./@types/libp2p";
 import {bytes, bytes32} from "./@types/basic";
-import {Hkdf} from "./@types/handshake";
+import {Hkdf, INoisePayload} from "./@types/handshake";
 import payloadProto from "./proto/payload.json";
 
 export async function loadPayloadProto () {
@@ -68,11 +68,11 @@ export async function getPeerIdFromPayload(payload: bytes): Promise<PeerId> {
   return await PeerId.createFromPubKey(Buffer.from(decodedPayload.identityKey));
 }
 
-async function decodePayload(payload: bytes){
+async function decodePayload(payload: bytes): Promise<INoisePayload> {
   const NoiseHandshakePayload = await loadPayloadProto();
   return NoiseHandshakePayload.toObject(
     NoiseHandshakePayload.decode(payload)
-  );
+  ) as INoisePayload;
 }
 
 export const getHandshakePayload = (publicKey: bytes ) => Buffer.concat([Buffer.from("noise-libp2p-static-key:"), publicKey]);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,7 +8,7 @@ import {bytes, bytes32} from "./@types/basic";
 import {Hkdf, INoisePayload} from "./@types/handshake";
 import payloadProto from "./proto/payload.json";
 
-export async function loadPayloadProto () {
+async function loadPayloadProto () {
   const payloadProtoBuf = await protobuf.Root.fromJSON(payloadProto);
   return payloadProtoBuf.lookupType("NoiseHandshakePayload");
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -63,6 +63,18 @@ export async function signPayload(peerId: PeerId, payload: bytes): Promise<bytes
   return peerId.privKey.sign(payload);
 }
 
+export async function getPeerIdFromPayload(payload: bytes): Promise<PeerId> {
+  const decodedPayload = await decodePayload(payload);
+  return await PeerId.createFromPubKey(Buffer.from(decodedPayload.identityKey));
+}
+
+async function decodePayload(payload: bytes){
+  const NoiseHandshakePayload = await loadPayloadProto();
+  return NoiseHandshakePayload.toObject(
+    NoiseHandshakePayload.decode(payload)
+  );
+}
+
 export const getHandshakePayload = (publicKey: bytes ) => Buffer.concat([Buffer.from("noise-libp2p-static-key:"), publicKey]);
 
 async function isValidPeerId(peerId: bytes, publicKeyProtobuf: bytes) {

--- a/test/ik-handshake.test.ts
+++ b/test/ik-handshake.test.ts
@@ -25,10 +25,10 @@ describe("IK Handshake", () => {
       const staticKeysResponder = generateKeypair();
 
       const initPayload = await getPayload(peerA, staticKeysInitiator.publicKey);
-      const handshakeInit = new IKHandshake(true, initPayload, prologue, staticKeysInitiator, connectionFrom, peerB, staticKeysResponder.publicKey);
+      const handshakeInit = new IKHandshake(true, initPayload, prologue, staticKeysInitiator, connectionFrom, staticKeysResponder.publicKey, peerB);
 
       const respPayload = await getPayload(peerB, staticKeysResponder.publicKey);
-      const handshakeResp = new IKHandshake(false, respPayload, prologue, staticKeysResponder, connectionTo, peerA, staticKeysInitiator.publicKey);
+      const handshakeResp = new IKHandshake(false, respPayload, prologue, staticKeysResponder, connectionTo, staticKeysInitiator.publicKey);
 
       await handshakeInit.stage0();
       await handshakeResp.stage0();
@@ -66,10 +66,10 @@ describe("IK Handshake", () => {
       const oldScammyKeys = generateKeypair();
 
       const initPayload = await getPayload(peerA, staticKeysInitiator.publicKey);
-      const handshakeInit = new IKHandshake(true, initPayload, prologue, staticKeysInitiator, connectionFrom, peerB, oldScammyKeys.publicKey);
+      const handshakeInit = new IKHandshake(true, initPayload, prologue, staticKeysInitiator, connectionFrom, oldScammyKeys.publicKey, peerB);
 
       const respPayload = await getPayload(peerB, staticKeysResponder.publicKey);
-      const handshakeResp = new IKHandshake(false, respPayload, prologue, staticKeysResponder, connectionTo, peerA, staticKeysInitiator.publicKey);
+      const handshakeResp = new IKHandshake(false, respPayload, prologue, staticKeysResponder, connectionTo, staticKeysInitiator.publicKey);
 
       await handshakeInit.stage0();
       await handshakeResp.stage0();

--- a/test/noise.test.ts
+++ b/test/noise.test.ts
@@ -275,7 +275,7 @@ describe("Noise", () => {
 
       // Prepare key cache for noise pipes
       KeyCache.resetStorage();
-      KeyCache.store(remotePeer, staticKeysResponder.publicKey);
+      KeyCache.store(localPeer, staticKeysResponder.publicKey);
 
       const [inboundConnection, outboundConnection] = DuplexPair();
 

--- a/test/noise.test.ts
+++ b/test/noise.test.ts
@@ -263,7 +263,7 @@ describe("Noise", () => {
     }
   });
 
-  it("IK -> XX Fallback: responder has no remote static key", async() => {
+  it("IK: responder has no remote static key", async() => {
     try {
       const staticKeysInitiator = generateKeypair();
       const noiseInit = new Noise(staticKeysInitiator.privateKey);
@@ -272,7 +272,7 @@ describe("Noise", () => {
       const noiseResp = new Noise(staticKeysResponder.privateKey);
       const ikInitSpy = sandbox.spy(noiseInit, "performIKHandshake");
       const xxFallbackInitSpy = sandbox.spy(noiseInit, "performXXFallbackHandshake");
-      const xxRespSpy = sandbox.spy(noiseResp, "performXXHandshake");
+      const ikRespSpy = sandbox.spy(noiseResp, "performIKHandshake");
 
       // Prepare key cache for noise pipes
       KeyCache.resetStorage();
@@ -293,8 +293,8 @@ describe("Noise", () => {
       expect(response.toString()).equal("test fallback");
 
       assert(ikInitSpy.calledOnce, "IK handshake was not called.");
-      assert(xxFallbackInitSpy.calledOnce, "XX Fallback method was not called.");
-      assert(xxRespSpy.calledOnce, "XX method was not called.");
+      assert(ikRespSpy.calledOnce, "IK handshake was not called.");
+      assert(xxFallbackInitSpy.notCalled, "XX Fallback method was called.");
     } catch (e) {
       console.error(e);
       assert(false, e.message);

--- a/test/noise.test.ts
+++ b/test/noise.test.ts
@@ -270,12 +270,13 @@ describe("Noise", () => {
       const staticKeysResponder = generateKeypair();
 
       const noiseResp = new Noise(staticKeysResponder.privateKey);
+      const ikInitSpy = sandbox.spy(noiseInit, "performIKHandshake");
       const xxFallbackInitSpy = sandbox.spy(noiseInit, "performXXFallbackHandshake");
       const xxRespSpy = sandbox.spy(noiseResp, "performXXHandshake");
 
       // Prepare key cache for noise pipes
       KeyCache.resetStorage();
-      KeyCache.store(localPeer, staticKeysResponder.publicKey);
+      KeyCache.store(remotePeer, staticKeysResponder.publicKey);
 
       const [inboundConnection, outboundConnection] = DuplexPair();
 
@@ -291,6 +292,7 @@ describe("Noise", () => {
       const response = await wrappedInbound.readLP();
       expect(response.toString()).equal("test fallback");
 
+      assert(ikInitSpy.calledOnce, "IK handshake was not called.");
       assert(xxFallbackInitSpy.calledOnce, "XX Fallback method was not called.");
       assert(xxRespSpy.calledOnce, "XX method was not called.");
     } catch (e) {

--- a/test/xx-fallback-handshake.test.ts
+++ b/test/xx-fallback-handshake.test.ts
@@ -39,7 +39,7 @@ describe("XX Fallback Handshake", () => {
 
       const respPayload = await getPayload(peerB, staticKeysResponder.publicKey);
       const handshakeResp =
-        new XXFallbackHandshake(false, respPayload, prologue, staticKeysResponder, connectionTo, peerA, initialMsgR);
+        new XXFallbackHandshake(false, respPayload, prologue, staticKeysResponder, connectionTo, initialMsgR, peerA);
 
       await handshakeResp.propose();
       await handshakeResp.exchange();
@@ -48,7 +48,7 @@ describe("XX Fallback Handshake", () => {
       // This is the point where initiator falls back from IK
       const initialMsgI = await connectionFrom.readLP();
       const handshakeInit =
-        new XXFallbackHandshake(true, handshakePayload, prologue, staticKeysInitiator, connectionFrom, peerB, initialMsgI, ephemeralKeys);
+        new XXFallbackHandshake(true, handshakePayload, prologue, staticKeysInitiator, connectionFrom, initialMsgI, peerB, ephemeralKeys);
 
       await handshakeInit.propose();
       await handshakeInit.exchange();


### PR DESCRIPTION
This is alternative to #31 

- remote peer is deducted from payload in message respective to the handshake type
- ik is tried if 
   - initiator + noise pipes + has remote static key
   - responder + noise pipes

Some tests are failing:
   - 2 are wrong as they assume you will receive remote peer on inbound connection
   - rest are failing because "Ephemeral keys doesn't exists"