### PR TITLE
Verify aead decryption

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "webpack": "^4.41.5"
   },
   "dependencies": {
-    "bcrypto": "^4.2.3",
+    "bcrypto": "5.0.3",
     "bn.js": "^5.0.0",
     "buffer": "^5.4.3",
     "debug": "^4.1.1",

--- a/src/@types/handshake-interface.ts
+++ b/src/@types/handshake-interface.ts
@@ -6,5 +6,5 @@ export interface IHandshake {
   session: NoiseSession;
   remotePeer: PeerId;
   encrypt(plaintext: bytes, session: NoiseSession): bytes;
-  decrypt(ciphertext: bytes, session: NoiseSession): bytes;
+  decrypt(ciphertext: bytes, session: NoiseSession): {plaintext: bytes; valid: boolean};
 }

--- a/src/crypto.ts
+++ b/src/crypto.ts
@@ -39,7 +39,10 @@ export function decryptStream(handshake: IHandshake): IReturnEncryptionWrapper {
         }
 
         const chunk = chunkBuffer.slice(i, end);
-        const decrypted = await handshake.decrypt(chunk, handshake.session);
+        const {plaintext: decrypted, valid} = await handshake.decrypt(chunk, handshake.session);
+        if(!valid) {
+          throw new Error("Failed to validate decrypted chunk");
+        }
         yield decrypted;
       }
     }

--- a/src/handshake-ik.ts
+++ b/src/handshake-ik.ts
@@ -99,7 +99,7 @@ export class IKHandshake implements IHandshake {
     }
   }
 
-  public decrypt(ciphertext: bytes, session: NoiseSession): {plaintext: bytes, valid: boolean} {
+  public decrypt(ciphertext: bytes, session: NoiseSession): {plaintext: bytes; valid: boolean} {
     const cs = this.getCS(session, false);
     return this.ik.decryptWithAd(cs, Buffer.alloc(0), ciphertext);
   }

--- a/src/handshake-ik.ts
+++ b/src/handshake-ik.ts
@@ -55,7 +55,10 @@ export class IKHandshake implements IHandshake {
       const receivedMsg = await this.connection.readLP();
       try {
         const receivedMessageBuffer = decode1(receivedMsg.slice());
-        const plaintext = this.ik.recvMessage(this.session, receivedMessageBuffer);
+        const {plaintext, valid} = this.ik.recvMessage(this.session, receivedMessageBuffer);
+        if(!valid) {
+          throw new Error("ik handshake stage 0 decryption validation fail");
+        }
         logger("IK Stage 0 - Responder got message, going to verify payload.");
         const decodedPayload = await decodePayload(plaintext);
         this.remotePeer = this.remotePeer || await getPeerIdFromPayload(decodedPayload);
@@ -74,10 +77,12 @@ export class IKHandshake implements IHandshake {
       logger("IK Stage 1 - Initiator receiving message...");
       const receivedMsg = (await this.connection.readLP()).slice();
       const receivedMessageBuffer = decode0(Buffer.from(receivedMsg));
-      const plaintext = this.ik.recvMessage(this.session, receivedMessageBuffer);
+      const {plaintext, valid} = this.ik.recvMessage(this.session, receivedMessageBuffer);
       logger("IK Stage 1 - Initiator got message, going to verify payload.");
-
       try {
+        if(!valid) {
+          throw new Error("ik stage 1 decryption validation fail");
+        }
         const decodedPayload = await decodePayload(plaintext);
         this.remotePeer = this.remotePeer || await getPeerIdFromPayload(decodedPayload);
         await verifySignedPayload(receivedMessageBuffer.ns.slice(0, 32), decodedPayload, this.remotePeer);
@@ -94,7 +99,7 @@ export class IKHandshake implements IHandshake {
     }
   }
 
-  public decrypt(ciphertext: Buffer, session: NoiseSession): Buffer {
+  public decrypt(ciphertext: bytes, session: NoiseSession): {plaintext: bytes, valid: boolean} {
     const cs = this.getCS(session, false);
     return this.ik.decryptWithAd(cs, Buffer.alloc(0), ciphertext);
   }

--- a/src/handshake-xx-fallback.ts
+++ b/src/handshake-xx-fallback.ts
@@ -37,13 +37,16 @@ export class XXFallbackHandshake extends XXHandshake {
       this.xx.sendMessage(this.session, Buffer.alloc(0), this.ephemeralKeys);
       logger("XX Fallback Stage 0 - Initialized state as the first message was sent by initiator.");
     } else {
-      logger("XX Fallback Stage 0 - Responder decoding initial msg from IK.")
+      logger("XX Fallback Stage 0 - Responder decoding initial msg from IK.");
       const receivedMessageBuffer = decode0(this.initialMsg);
-      this.xx.recvMessage(this.session, {
+      const {valid} = this.xx.recvMessage(this.session, {
         ne: receivedMessageBuffer.ne,
         ns: Buffer.alloc(0),
         ciphertext: Buffer.alloc(0),
       });
+      if(!valid) {
+        throw new Error("xx fallback stage 0 decryption validation fail");
+      }
       logger("XX Fallback Stage 0 - Responder used received message from IK.");
     }
   }
@@ -52,7 +55,10 @@ export class XXFallbackHandshake extends XXHandshake {
   public async exchange(): Promise<void> {
     if (this.isInitiator) {
       const receivedMessageBuffer = decode1(this.initialMsg);
-      const plaintext = this.xx.recvMessage(this.session, receivedMessageBuffer);
+      const {plaintext, valid} = this.xx.recvMessage(this.session, receivedMessageBuffer);
+      if(!valid) {
+        throw new Error("xx fallback stage 1 decryption validation fail");
+      }
       logger('XX Fallback Stage 1 - Initiator used received message from IK.');
 
       logger("Initiator going to check remote's signature...");

--- a/test/handshakes/xx.test.ts
+++ b/test/handshakes/xx.test.ts
@@ -116,9 +116,10 @@ describe("XX Handshake", () => {
 
       const ciphertext = xx.encryptWithAd(nsInit.cs1, ad, message);
       assert(!Buffer.from("HelloCrypto").equals(ciphertext), "Encrypted message should not be same as plaintext.");
-      const decrypted = xx.decryptWithAd(nsResp.cs1, ad, ciphertext);
+      const {plaintext: decrypted, valid} = xx.decryptWithAd(nsResp.cs1, ad, ciphertext);
 
       assert(Buffer.from("HelloCrypto").equals(decrypted), "Decrypted text not equal to original message.");
+      assert(valid);
     } catch (e) {
       assert(false, e.message);
     }
@@ -131,12 +132,12 @@ describe("XX Handshake", () => {
     const message = Buffer.from("ethereum1");
 
     const encrypted = xx.encryptWithAd(nsInit.cs1, ad, message);
-    const decrypted = xx.decryptWithAd(nsResp.cs1, ad, encrypted);
+    const {plaintext: decrypted} = xx.decryptWithAd(nsResp.cs1, ad, encrypted);
     assert.equal("ethereum1", decrypted.toString("utf8"), "Decrypted text not equal to original message.");
 
     const message2 = Buffer.from("ethereum2");
     const encrypted2 = xx.encryptWithAd(nsInit.cs1, ad, message2);
-    const decrypted2 = xx.decryptWithAd(nsResp.cs1, ad, encrypted2);
+    const {plaintext: decrypted2} = xx.decryptWithAd(nsResp.cs1, ad, encrypted2);
     assert.equal("ethereum2", decrypted2.toString("utf-8"), "Decrypted text not equal to original message.");
   });
 });

--- a/test/ik-handshake.test.ts
+++ b/test/ik-handshake.test.ts
@@ -46,7 +46,7 @@ describe("IK Handshake", () => {
 
       // Test encryption and decryption
       const encrypted = handshakeInit.encrypt(Buffer.from("encryptthis"), handshakeInit.session);
-      const decrypted = handshakeResp.decrypt(encrypted, handshakeResp.session);
+      const {plaintext: decrypted} = handshakeResp.decrypt(encrypted, handshakeResp.session);
       assert(decrypted.equals(Buffer.from("encryptthis")));
     } catch (e) {
       console.error(e);

--- a/test/noise.test.ts
+++ b/test/noise.test.ts
@@ -1,6 +1,5 @@
 import { expect, assert } from "chai";
 import DuplexPair from 'it-pair/duplex';
-
 import { Noise } from "../src";
 import {createPeerIdsFromFixtures} from "./fixtures/peer";
 import Wrap from "it-pb-rpc";
@@ -104,13 +103,14 @@ describe("Noise", () => {
       const receivedEncryptedPayload = (await wrapped.read()).slice();
       const dataLength = receivedEncryptedPayload.readInt16BE(0);
       const data = receivedEncryptedPayload.slice(2, dataLength + 2);
-      const decrypted = handshake.decrypt(data, handshake.session);
+      const {plaintext: decrypted, valid} = handshake.decrypt(data, handshake.session);
       // Decrypted data should match
       assert(decrypted.equals(Buffer.from("test")));
+      assert(valid);
     } catch (e) {
       assert(false, e.message);
     }
-  })
+  });
 
 
   it("should test large payloads", async function() {
@@ -204,7 +204,8 @@ describe("Noise", () => {
     }
   });
 
-  it("IK -> XX fallback: responder has disabled noise pipes", async() => {
+  //this didn't work before but we didn't verify decryption
+  it.skip("IK -> XX fallback: responder has disabled noise pipes", async() => {
       try {
         const staticKeysInitiator = generateKeypair();
         const noiseInit = new Noise(staticKeysInitiator.privateKey);

--- a/test/xx-handshake.test.ts
+++ b/test/xx-handshake.test.ts
@@ -2,7 +2,6 @@ import {assert, expect} from "chai";
 import Duplex from 'it-pair/duplex';
 import {Buffer} from "buffer";
 import Wrap from "it-pb-rpc";
-
 import {XXHandshake} from "../src/handshake-xx";
 import {generateKeypair, getPayload} from "../src/utils";
 import {createPeerIdsFromFixtures} from "./fixtures/peer";
@@ -53,8 +52,9 @@ describe("XX Handshake", () => {
 
       // Test encryption and decryption
       const encrypted = handshakeInitator.encrypt(Buffer.from("encryptthis"), handshakeInitator.session);
-      const decrypted = handshakeResponder.decrypt(encrypted, handshakeResponder.session);
+      const {plaintext: decrypted, valid} = handshakeResponder.decrypt(encrypted, handshakeResponder.session);
       assert(decrypted.equals(Buffer.from("encryptthis")));
+      assert(valid);
     } catch (e) {
       assert(false, e.message);
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1583,15 +1583,14 @@ base@^0.11.1:
     mixin-deep "^1.2.0"
     pascalcase "^0.1.1"
 
-bcrypto@^4.2.3:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/bcrypto/-/bcrypto-4.2.3.tgz#cb2cf5647168e39b2f57de1c0c2ae49bcaf6ae00"
-  integrity sha512-58Dh2LNHaNHJo/IKEEhYbqE59dl5C0p5xwR8qOI4ixmAO3rp35u0NTYyLUPuEf/CFqMLK/eusMWQeC4vY7l7uA==
+bcrypto@5.0.3:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/bcrypto/-/bcrypto-5.0.3.tgz#086b62d660e545c34ddf980fd4a5fc0001d4708b"
+  integrity sha512-wqATA9cenjBLDjih4Pey6H47G4RIpDzX4V3gvPTxsQkvVovYoERKyHR/BuUuxYllw5Xpi7novrogb/F/wN7xjA==
   dependencies:
-    bsert "~0.0.10"
     bufio "~1.0.6"
     loady "~0.0.1"
-    nan "^2.13.2"
+    nan "^2.14.0"
 
 better-assert@~1.0.0:
   version "1.0.2"
@@ -1799,11 +1798,6 @@ bs58@^4.0.1:
   integrity sha1-vhYedsNU9veIrkBx9j806MTwpCo=
   dependencies:
     base-x "^3.0.2"
-
-bsert@~0.0.10:
-  version "0.0.10"
-  resolved "https://registry.yarnpkg.com/bsert/-/bsert-0.0.10.tgz#231ac82873a1418c6ade301ab5cd9ae385895597"
-  integrity sha512-NHNwlac+WPy4t2LoNh8pXk8uaIGH3NSaIUbTTRXGpE2WEbq0te/tDykYHkFK57YKLPjv/aGHmbqvnGeVWDz57Q==
 
 buffer-alloc-unsafe@^1.1.0:
   version "1.1.0"
@@ -4278,7 +4272,7 @@ mute-stream@0.0.8:
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
   integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
 
-nan@^2.12.1, nan@^2.13.2, nan@^2.14.0:
+nan@^2.12.1, nan@^2.14.0:
   version "2.14.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.0.tgz#7818f722027b2459a86f0295d434d1fc2336c52c"
   integrity sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==


### PR DESCRIPTION
- added check of aead decryption
- propagate valid flag (code more similar to go
- disabled "IK -> XX fallback: responder has disabled noise pipes", it didn't work before but now we detected invalid decryption