### PR TITLE
Early data api

### DIFF
--- a/src/@types/handshake-interface.ts
+++ b/src/@types/handshake-interface.ts
@@ -5,6 +5,7 @@ import PeerId from "peer-id";
 export interface IHandshake {
   session: NoiseSession;
   remotePeer: PeerId;
+  earlyData: Uint8Array;
   encrypt(plaintext: bytes, session: NoiseSession): bytes;
   decrypt(ciphertext: bytes, session: NoiseSession): {plaintext: bytes; valid: boolean};
 }

--- a/src/@types/handshake-interface.ts
+++ b/src/@types/handshake-interface.ts
@@ -5,7 +5,7 @@ import PeerId from "peer-id";
 export interface IHandshake {
   session: NoiseSession;
   remotePeer: PeerId;
-  earlyData: Buffer;
+  remoteEarlyData: Buffer;
   encrypt(plaintext: bytes, session: NoiseSession): bytes;
   decrypt(ciphertext: bytes, session: NoiseSession): {plaintext: bytes; valid: boolean};
 }

--- a/src/@types/handshake-interface.ts
+++ b/src/@types/handshake-interface.ts
@@ -5,7 +5,7 @@ import PeerId from "peer-id";
 export interface IHandshake {
   session: NoiseSession;
   remotePeer: PeerId;
-  earlyData: Uint8Array;
+  earlyData: Buffer;
   encrypt(plaintext: bytes, session: NoiseSession): bytes;
   decrypt(ciphertext: bytes, session: NoiseSession): {plaintext: bytes; valid: boolean};
 }

--- a/src/@types/libp2p.ts
+++ b/src/@types/libp2p.ts
@@ -14,7 +14,7 @@ export interface INoiseConnection {
 
 export type SecureOutbound = {
   conn: any;
-  earlyData: Uint8Array;
+  earlyData: Buffer;
   remotePeer: PeerId;
 }
 

--- a/src/@types/libp2p.ts
+++ b/src/@types/libp2p.ts
@@ -14,6 +14,7 @@ export interface INoiseConnection {
 
 export type SecureOutbound = {
   conn: any;
+  earlyData: Uint8Array;
   remotePeer: PeerId;
 }
 

--- a/src/@types/libp2p.ts
+++ b/src/@types/libp2p.ts
@@ -14,7 +14,7 @@ export interface INoiseConnection {
 
 export type SecureOutbound = {
   conn: any;
-  earlyData: Buffer;
+  remoteEarlyData: Buffer;
   remotePeer: PeerId;
 }
 

--- a/src/handshake-ik.ts
+++ b/src/handshake-ik.ts
@@ -15,7 +15,7 @@ export class IKHandshake implements IHandshake {
   public isInitiator: boolean;
   public session: NoiseSession;
   public remotePeer!: PeerId;
-  public earlyData: Uint8Array;
+  public earlyData: Buffer;
 
   private payload: bytes;
   private prologue: bytes32;
@@ -135,7 +135,7 @@ export class IKHandshake implements IHandshake {
 
   private setEarlyData(data: Uint8Array|null|undefined): void {
     if(data){
-      this.earlyData = data;
+      this.earlyData = Buffer.from(data.buffer, data.byteOffset, data.length);
     }
   }
 }

--- a/src/handshake-ik.ts
+++ b/src/handshake-ik.ts
@@ -15,7 +15,7 @@ export class IKHandshake implements IHandshake {
   public isInitiator: boolean;
   public session: NoiseSession;
   public remotePeer!: PeerId;
-  public earlyData: Buffer;
+  public remoteEarlyData: Buffer;
 
   private payload: bytes;
   private prologue: bytes32;
@@ -43,7 +43,7 @@ export class IKHandshake implements IHandshake {
     }
     this.ik = handshake || new IK();
     this.session = this.ik.initSession(this.isInitiator, this.prologue, this.staticKeypair, remoteStaticKey);
-    this.earlyData = Buffer.alloc(0)
+    this.remoteEarlyData = Buffer.alloc(0)
   }
 
   public async stage0(): Promise<void> {

--- a/src/handshake-ik.ts
+++ b/src/handshake-ik.ts
@@ -65,7 +65,7 @@ export class IKHandshake implements IHandshake {
         const decodedPayload = await decodePayload(plaintext);
         this.remotePeer = this.remotePeer || await getPeerIdFromPayload(decodedPayload);
         await verifySignedPayload(this.session.hs.rs, decodedPayload, this.remotePeer);
-        this.setEarlyData(decodedPayload.data);
+        this.setRemoteEarlyData(decodedPayload.data);
         logger("IK Stage 0 - Responder successfully verified payload!");
       } catch (e) {
         logger("Responder breaking up with IK handshake in stage 0.");
@@ -89,7 +89,7 @@ export class IKHandshake implements IHandshake {
         const decodedPayload = await decodePayload(plaintext);
         this.remotePeer = this.remotePeer || await getPeerIdFromPayload(decodedPayload);
         await verifySignedPayload(receivedMessageBuffer.ns.slice(0, 32), decodedPayload, this.remotePeer);
-        this.setEarlyData(decodedPayload.data);
+        this.setRemoteEarlyData(decodedPayload.data);
         logger("IK Stage 1 - Initiator successfully verified payload!");
       } catch (e) {
         logger("Initiator breaking up with IK handshake in stage 1.");
@@ -133,7 +133,7 @@ export class IKHandshake implements IHandshake {
     }
   }
 
-  private setEarlyData(data: Uint8Array|null|undefined): void {
+  private setRemoteEarlyData(data: Uint8Array|null|undefined): void {
     if(data){
       this.remoteEarlyData = Buffer.from(data.buffer, data.byteOffset, data.length);
     }

--- a/src/handshake-ik.ts
+++ b/src/handshake-ik.ts
@@ -135,7 +135,7 @@ export class IKHandshake implements IHandshake {
 
   private setEarlyData(data: Uint8Array|null|undefined): void {
     if(data){
-      this.earlyData = Buffer.from(data.buffer, data.byteOffset, data.length);
+      this.remoteEarlyData = Buffer.from(data.buffer, data.byteOffset, data.length);
     }
   }
 }

--- a/src/handshake-xx-fallback.ts
+++ b/src/handshake-xx-fallback.ts
@@ -67,7 +67,7 @@ export class XXFallbackHandshake extends XXHandshake {
         this.remotePeer = this.remotePeer || await getPeerIdFromPayload(decodedPayload);
         await verifySignedPayload(this.session.hs.rs, decodedPayload, this.remotePeer);
         if(decodedPayload.data){
-          this.earlyData = Buffer.from(
+          this.remoteEarlyData = Buffer.from(
             decodedPayload.data.buffer, 
             decodedPayload.data.byteOffset, 
             decodedPayload.data.length

--- a/src/handshake-xx-fallback.ts
+++ b/src/handshake-xx-fallback.ts
@@ -67,7 +67,11 @@ export class XXFallbackHandshake extends XXHandshake {
         this.remotePeer = this.remotePeer || await getPeerIdFromPayload(decodedPayload);
         await verifySignedPayload(this.session.hs.rs, decodedPayload, this.remotePeer);
         if(decodedPayload.data){
-          this.earlyData = decodedPayload.data;
+          this.earlyData = Buffer.from(
+            decodedPayload.data.buffer, 
+            decodedPayload.data.byteOffset, 
+            decodedPayload.data.length
+          );
         }
       } catch (e) {
         throw new Error(`Error occurred while verifying signed payload from responder: ${e.message}`);

--- a/src/handshake-xx-fallback.ts
+++ b/src/handshake-xx-fallback.ts
@@ -66,13 +66,7 @@ export class XXFallbackHandshake extends XXHandshake {
         const decodedPayload = await decodePayload(plaintext);
         this.remotePeer = this.remotePeer || await getPeerIdFromPayload(decodedPayload);
         await verifySignedPayload(this.session.hs.rs, decodedPayload, this.remotePeer);
-        if(decodedPayload.data){
-          this.remoteEarlyData = Buffer.from(
-            decodedPayload.data.buffer, 
-            decodedPayload.data.byteOffset, 
-            decodedPayload.data.length
-          );
-        }
+        this.setRemoteEarlyData(decodedPayload.data)
       } catch (e) {
         throw new Error(`Error occurred while verifying signed payload from responder: ${e.message}`);
       }

--- a/src/handshake-xx-fallback.ts
+++ b/src/handshake-xx-fallback.ts
@@ -66,6 +66,9 @@ export class XXFallbackHandshake extends XXHandshake {
         const decodedPayload = await decodePayload(plaintext);
         this.remotePeer = this.remotePeer || await getPeerIdFromPayload(decodedPayload);
         await verifySignedPayload(this.session.hs.rs, decodedPayload, this.remotePeer);
+        if(decodedPayload.data){
+          this.earlyData = decodedPayload.data;
+        }
       } catch (e) {
         throw new Error(`Error occurred while verifying signed payload from responder: ${e.message}`);
       }

--- a/src/handshake-xx.ts
+++ b/src/handshake-xx.ts
@@ -84,7 +84,7 @@ export class XXHandshake implements IHandshake {
         const decodedPayload = await decodePayload(plaintext);
         this.remotePeer = this.remotePeer || await getPeerIdFromPayload(decodedPayload);
         this.remotePeer = await verifySignedPayload(receivedMessageBuffer.ns, decodedPayload, this.remotePeer);
-        this.setEarlyData(decodedPayload.data)
+        this.setRemoteEarlyData(decodedPayload.data)
       } catch (e) {
         throw new Error(`Error occurred while verifying signed payload: ${e.message}`);
       }
@@ -117,7 +117,7 @@ export class XXHandshake implements IHandshake {
         const decodedPayload = await decodePayload(plaintext);
         this.remotePeer = this.remotePeer || await getPeerIdFromPayload(decodedPayload);
         await verifySignedPayload(this.session.hs.rs, decodedPayload, this.remotePeer);
-        this.setEarlyData(decodedPayload.data)
+        this.setRemoteEarlyData(decodedPayload.data)
       } catch (e) {
         throw new Error(`Error occurred while verifying signed payload: ${e.message}`);
       }
@@ -151,7 +151,7 @@ export class XXHandshake implements IHandshake {
     }
   }
 
-  private setEarlyData(data: Uint8Array|null|undefined): void {
+  private setRemoteEarlyData(data: Uint8Array|null|undefined): void {
     if(data){
       this.remoteEarlyData = Buffer.from(data.buffer, data.byteOffset, data.length);
     }

--- a/src/handshake-xx.ts
+++ b/src/handshake-xx.ts
@@ -19,7 +19,7 @@ export class XXHandshake implements IHandshake {
   public isInitiator: boolean;
   public session: NoiseSession;
   public remotePeer!: PeerId;
-  public earlyData: Buffer;
+  public remoteEarlyData: Buffer;
 
   protected payload: bytes;
   protected connection: WrappedConnection;
@@ -47,7 +47,7 @@ export class XXHandshake implements IHandshake {
     }
     this.xx = handshake || new XX();
     this.session = this.xx.initSession(this.isInitiator, this.prologue, this.staticKeypair);
-    this.earlyData = Buffer.alloc(0)
+    this.remoteEarlyData = Buffer.alloc(0)
   }
 
   // stage 0
@@ -153,7 +153,7 @@ export class XXHandshake implements IHandshake {
 
   private setEarlyData(data: Uint8Array|null|undefined): void {
     if(data){
-      this.earlyData = Buffer.from(data.buffer, data.byteOffset, data.length);
+      this.remoteEarlyData = Buffer.from(data.buffer, data.byteOffset, data.length);
     }
   }
 }

--- a/src/handshake-xx.ts
+++ b/src/handshake-xx.ts
@@ -19,7 +19,7 @@ export class XXHandshake implements IHandshake {
   public isInitiator: boolean;
   public session: NoiseSession;
   public remotePeer!: PeerId;
-  public earlyData: Uint8Array;
+  public earlyData: Buffer;
 
   protected payload: bytes;
   protected connection: WrappedConnection;
@@ -153,7 +153,7 @@ export class XXHandshake implements IHandshake {
 
   private setEarlyData(data: Uint8Array|null|undefined): void {
     if(data){
-      this.earlyData = data
+      this.earlyData = Buffer.from(data.buffer, data.byteOffset, data.length);
     }
   }
 }

--- a/src/handshake-xx.ts
+++ b/src/handshake-xx.ts
@@ -151,7 +151,7 @@ export class XXHandshake implements IHandshake {
     }
   }
 
-  private setRemoteEarlyData(data: Uint8Array|null|undefined): void {
+  protected setRemoteEarlyData(data: Uint8Array|null|undefined): void {
     if(data){
       this.remoteEarlyData = Buffer.from(data.buffer, data.byteOffset, data.length);
     }

--- a/src/noise.ts
+++ b/src/noise.ts
@@ -85,7 +85,7 @@ export class Noise implements INoiseConnection {
 
     return {
       conn,
-      earlyData: handshake.earlyData,
+      remoteEarlyData: handshake.remoteEarlyData,
       remotePeer: handshake.remotePeer,
     }
   }

--- a/src/noise.ts
+++ b/src/noise.ts
@@ -116,7 +116,7 @@ export class Noise implements INoiseConnection {
 
     return {
       conn,
-      earlyData: handshake.earlyData,
+      remoteEarlyData: handshake.remoteEarlyData,
       remotePeer: handshake.remotePeer
     };
   }

--- a/src/noise.ts
+++ b/src/noise.ts
@@ -85,6 +85,7 @@ export class Noise implements INoiseConnection {
 
     return {
       conn,
+      earlyData: handshake.earlyData,
       remotePeer: handshake.remotePeer,
     }
   }
@@ -115,6 +116,7 @@ export class Noise implements INoiseConnection {
 
     return {
       conn,
+      earlyData: handshake.earlyData,
       remotePeer: handshake.remotePeer
     };
   }

--- a/test/noise.test.ts
+++ b/test/noise.test.ts
@@ -355,8 +355,8 @@ describe("Noise", () => {
         noiseResp.secureInbound(remotePeer, inboundConnection),
       ]);
 
-      assert(inbound.earlyData.equals(localPeerEarlyData))
-      assert(outbound.earlyData.equals(Buffer.alloc(0)))
+      assert(inbound.remoteEarlyData.equals(localPeerEarlyData))
+      assert(outbound.remoteEarlyData.equals(Buffer.alloc(0)))
     } catch (e) {
       console.error(e);
       assert(false, e.message);


### PR DESCRIPTION
Set remote early data when remote peer payload is verified and return from secureOutbound and secureInbound.

Related to issue: #53 