### PR TITLE
fix: marshal the verified peer from its public key

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -97,7 +97,7 @@ export async function verifySignedPayload(
   if (!payload.identitySig || !publicKey.verify(generatedPayload, Buffer.from(payload.identitySig))) {
     throw new Error("Static key doesn't match to peer that signed payload!");
   }
-  return remotePeer;
+  return PeerId.createFromPubKey(identityKey);
 }
 
 export function getHkdf(ck: bytes32, ikm: bytes): Hkdf {


### PR DESCRIPTION
Currently in outbound xx handshakes we don't ensure the remotePeer contains a public key. To correct this I updated `verifySignedPayload` to create the key from the validated public key. While this is redundant for inline keys, it's necessary for rsa keys.

The remotePeer is already being assigned to the result of `verifySignedPayload`. In order for tests to catch this it would require a test with RSA keys instead of ed25519. Happy to add those tests if desired.


Resolves: https://github.com/NodeFactoryIo/js-libp2p-noise/issues/58