### PR TITLE
chore: use http link for github repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,10 @@
   "files": [
     "dist"
   ],
-  "repository": "git@github.com:NodeFactoryIo/js-libp2p-noise.git",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/NodeFactoryIo/js-libp2p-noise.git"
+  },
   "author": "NodeFactory <info@nodefactory.io>",
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
The [page for this module on npm](https://www.npmjs.com/package/libp2p-noise) doesn't have a link to the repo, I guess because it's specified as an ssh-type URL in the package.json file so npm can't turn it into a hyperlink.

The change here is to use a `git+https` URL which should let npm display a link on the module page.